### PR TITLE
Allow configuring channels' buffer length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+# v0.2.0
+
+* Inter-node communication input channels are now unbuffered by default. To make them buffered,
+  you can append the `node.ChannelBufferLen` function to the `AsMiddle` and `AsTerminal` functions.
+
 # v0.1.1
 
 * Added InType and OutType inspection functions to the Nodes

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -85,6 +85,125 @@ func TestTypeCapture(t *testing.T) {
 	assert.Equal(t, reflect.TypeOf([]string{}), testColl.OutType())
 }
 
+func TestConfigurationOptions_UnbufferedChannelCommunication(t *testing.T) {
+	graphIn, graphOut := make(chan int), make(chan int)
+	endInit, endMiddle, endTerm := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	init := AsInit(func(out chan<- int) {
+		n := <-graphIn
+		out <- n
+		close(endInit)
+	})
+	middle := AsMiddle(func(in <-chan int, out chan<- int) {
+		n := <-in
+		out <- n
+		close(endMiddle)
+	})
+	term := AsTerminal(func(in <-chan int) {
+		n := <-in
+		graphOut <- n
+		close(endTerm)
+	})
+	init.SendsTo(middle)
+	middle.SendsTo(term)
+	init.Start()
+
+	graphIn <- 123
+	// Since the nodes are unbuffered, they are blocked and can't accept/process data until
+	// the last node exports it
+	select {
+	case <-endInit:
+		require.Fail(t, "expected that init node is still blocked")
+	default: //ok!
+	}
+	select {
+	case <-endMiddle:
+		require.Fail(t, "expected that middle node is still blocked")
+	default: //ok!
+	}
+	select {
+	case <-endTerm:
+		require.Fail(t, "expected that terminal node is still blocked")
+	default: //ok!
+	}
+	// After the last stage has exported the data, the rest of the channels are unblocked
+	select {
+	case <-graphOut: //ok!
+	case <-time.After(timeout):
+		require.Fail(t, "timeout while waiting for the terminal node to forward the data")
+	}
+	select {
+	case <-endInit: //ok!
+	case <-time.After(timeout):
+		require.Fail(t, "timeout while waiting for the init node to finish")
+	}
+	select {
+	case <-endMiddle: //ok!
+	case <-time.After(timeout):
+		require.Fail(t, "timeout while waiting for the middle node to finish")
+	}
+	select {
+	case <-endTerm: //ok!
+	case <-time.After(timeout):
+		require.Fail(t, "timeout while waiting for the terminal node to finish")
+	}
+}
+
+func TestConfigurationOptions_BufferedChannelCommunication(t *testing.T) {
+	graphIn, graphOut := make(chan int), make(chan int)
+	endInit, endMiddle, endTerm := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	init := AsInit(func(out chan<- int) {
+		n := <-graphIn
+		out <- n
+		close(endInit)
+	})
+	middle := AsMiddle(func(in <-chan int, out chan<- int) {
+		n := <-in
+		out <- n
+		close(endMiddle)
+	}, ChannelBufferLen(1))
+	term := AsTerminal(func(in <-chan int) {
+		n := <-in
+		graphOut <- n
+		close(endTerm)
+	}, ChannelBufferLen(1))
+	init.SendsTo(middle)
+	middle.SendsTo(term)
+	init.Start()
+
+	graphIn <- 123
+	// Since the nodes are buffered, they can keep accepting/processing data even if the last
+	// node hasn't exported it
+
+	select {
+	case <-endInit: //ok!
+	case <-time.After(timeout):
+		require.Fail(t, "timeout while waiting for the init node to finish")
+	}
+	select {
+	case <-endMiddle: //ok!
+	case <-time.After(timeout):
+		require.Fail(t, "timeout while waiting for the middle node to finish")
+	}
+	select {
+	case <-endTerm:
+		require.Fail(t, "expected that terminal node is still blocked")
+	default: //ok!
+	}
+
+	// unblock terminal node
+	select {
+	case <-graphOut: //ok!
+	case <-time.After(timeout):
+		require.Fail(t, "timeout while waiting for the terminal node to forward the data")
+	}
+	select {
+	case <-endTerm: //ok!
+	case <-time.After(timeout):
+		require.Fail(t, "timeout while waiting for the terminal node to finish")
+	}
+
+}
+
 func TestGraphVerification(t *testing.T) {
 	assert.Panics(t, func() {
 		_ = AsInit(func(out <-chan int) {})

--- a/pkg/node/options.go
+++ b/pkg/node/options.go
@@ -1,0 +1,22 @@
+package node
+
+type creationOptions struct {
+	// if 0, channel is unbuffered
+	channelBufferLen int
+}
+
+var defaultOptions = creationOptions{
+	channelBufferLen: 0,
+}
+
+// CreationOption allows overriding the default values of node instantiation
+type CreationOption func(options *creationOptions)
+
+// ChannelBufferLen is a node.CreationOption that allows specifying the length of the input
+// channels for a given node. The default value is 0, which means that the channels
+// are unbuffered.
+func ChannelBufferLen(length int) CreationOption {
+	return func(options *creationOptions) {
+		options.channelBufferLen = length
+	}
+}


### PR DESCRIPTION
Inter-node communication input channels are now unbuffered by default. To make them buffered,
you can append the `node.ChannelBufferLen` function to the `AsMiddle` and `AsTerminal` functions.